### PR TITLE
Pass arguments to adapters

### DIFF
--- a/lib/saddle/options.rb
+++ b/lib/saddle/options.rb
@@ -56,7 +56,8 @@ module Saddle
       30
     end
 
-    # Support specification of the HTTP adapter being used
+    # Support specification of the HTTP adapter being used. Returns a symbol or
+    # hash of the form { :key => :net_http, :args => [ ... ] }.
     def http_adapter
       :net_http
     end

--- a/lib/saddle/requester.rb
+++ b/lib/saddle/requester.rb
@@ -58,8 +58,13 @@ module Saddle
       raise ':additional_middleware must be an Array' unless @additional_middlewares.is_a?(Array)
       raise 'invalid middleware found' unless @additional_middlewares.all? { |m| m[:klass] < Faraday::Middleware }
       raise 'middleware arguments must be an array' unless @additional_middlewares.all? { |m| m[:args].nil? || m[:args].is_a?(Array) }
+
       @http_adapter = opt[:http_adapter] || :net_http
-      raise ':http_adapter must be a symbol' unless @http_adapter.is_a?(Symbol)
+      raise ':http_adapter must be a symbol or a hash' unless @http_adapter.is_a?(Symbol) || @http_adapter.is_a?(Hash)
+      @http_adapter = { :key => @http_adapter } if @http_adapter.is_a?(Symbol)
+      raise 'adapter key must be a symbol' unless @http_adapter[:key].is_a?(Symbol)
+      raise 'adapter arguments must be an array' unless @http_adapter[:args].nil? || @http_adapter[:args].is_a?(Array)
+
       @stubs = opt[:stubs] || nil
       unless @stubs.nil?
         raise ':stubs must be a Faraday::Adapter::Test::Stubs' unless @stubs.is_a?(Faraday::Adapter::Test::Stubs)
@@ -164,7 +169,7 @@ module Saddle
         # Set up our adapter
         if @stubs.nil?
           # Use the default adapter
-          builder.adapter(@http_adapter)
+          builder.adapter(@http_adapter[:key], *@http_adapter[:args])
         else
           # Use the test adapter
           builder.adapter(:test, @stubs)


### PR DESCRIPTION
Although Saddle permits the specification of arbitrary Faraday adapters, there's presently no way to pass arguments to the initializer. This pull request extends the `:http_adapter` client option to specify both in a backward-compatible manner. Now it's possible to make good use of all third-party adapters. ;)

``` ruby
def self.http_adapter
  {
    :key => :thrawn,
    :args => [{
      :strategy         => :synapse,
      :down_failures    => 2,
      :down_retry_delay => 30,
      :max_requests     => 100
    }]
  }
end
```

_The decision to use `:key` to designate the registered symbol of an adapter middleware was motivated by the internal name given to it in Faraday. See_ https://github.com/lostisland/faraday/blob/master/lib/faraday/rack_builder.rb#L99.

/cc @mLewisLogic 
