### PR TITLE
Add option to return full response object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # RVM
 .rvmrc
 
+# rbenv
+.ruby-version
+
 # Gems
 *.gem
 Gemfile.lock

--- a/lib/saddle/options.rb
+++ b/lib/saddle/options.rb
@@ -16,7 +16,8 @@ module Saddle
         :timeout => timeout,
         :http_adapter => http_adapter,
         :stubs => stubs,
-        :additional_middlewares => self.additional_middlewares,
+        :return_full_response => return_full_response,
+        :additional_middlewares => self.additional_middlewares
       }
     end
 
@@ -67,7 +68,10 @@ module Saddle
       nil
     end
 
-
+    # Should the client return the full response object, or just the body?
+    def return_full_response
+      false
+    end
 
     # Use this to add additional middleware to the request stack
     # ex:

--- a/lib/saddle/requester.rb
+++ b/lib/saddle/requester.rb
@@ -69,6 +69,7 @@ module Saddle
       unless @stubs.nil?
         raise ':stubs must be a Faraday::Adapter::Test::Stubs' unless @stubs.is_a?(Faraday::Adapter::Test::Stubs)
       end
+      @return_full_response = opt[:return_full_response] || false
     end
 
 
@@ -78,7 +79,7 @@ module Saddle
         req.options.deep_merge!(options)
         req.url(url, params)
       end
-      response.body
+      handle_response(response)
     end
 
     # Make a POST request
@@ -88,7 +89,7 @@ module Saddle
         req.url(url)
         req.body = data
       end
-      response.body
+      handle_response(response)
     end
 
     # Make a PUT request
@@ -98,7 +99,7 @@ module Saddle
         req.url(url)
         req.body = data
       end
-      response.body
+      handle_response(response)
     end
 
     # Make a DELETE request
@@ -107,12 +108,17 @@ module Saddle
         req.options.deep_merge!(options)
         req.url(url, params)
       end
-      response.body
+      handle_response(response)
     end
 
 
 
     private
+
+    # Return the appropriate response format based on options
+    def handle_response response
+      @return_full_response ? response : response.body
+    end
 
     # Construct a base url using this requester's settings
     def base_url


### PR DESCRIPTION
Include a configuration option to return the full Faraday response object so that clients can have access to the entire response (status code, headers, etc.)
