### PR TITLE
Removing Airbrake from Rails logger middleware

### DIFF
--- a/lib/saddle/middleware/logging/rails.rb
+++ b/lib/saddle/middleware/logging/rails.rb
@@ -1,4 +1,3 @@
-require 'airbrake'
 require 'faraday'
 
 


### PR DESCRIPTION
Removing Airbrake `require` from Rails Logger middleware to avoid errors when Airbrake is not defined.
