### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on: [pull_request, push]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: # use bundler 2.3 for ruby versions < 2.6 (https://bundler.io/compatibility.html)
+        - ruby-version: 2.3
+          bundler-version: 2.3
+        - ruby-version: 2.4
+          bundler-version: 2.3
+        - ruby-version: 2.5
+          bundler-version: 2.3
+        - ruby-version: 2.6
+          bundler-version: latest
+        - ruby-version: 2.7
+          bundler-version: latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler: ${{ matrix.bundler-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run rspec
+      run: bundle exec rspec


### PR DESCRIPTION
### Summary
Add Github Actions to run specs against different ruby versions

### Why?

This will be useful to check that code changes add or remove support for Ruby versions. Currently from Ruby 2.3 to 2.6 pass all tests.